### PR TITLE
fix(ci): replace fake action SHA pins (niche-actions estate sweep)

### DIFF
--- a/.github/workflows/main_sweb-app.yml
+++ b/.github/workflows/main_sweb-app.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: deno-app
 
-      - uses: azure/webapps-deploy@2fdd5c3ebb4f540834e86ecc1f6fdcd5539023ee # v3.0.2
+      - uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.2
         id: deploy-to-webapp
         with:
           app-name: 'sweb-app'


### PR DESCRIPTION
Estate fake-SHA sweep — niche actions (round-3). Version-faithful where possible; bumped to nearest in-major where the version comment itself was hallucinated. All real SHAs verified via `gh api`.

See `project_estate_fake_action_sha_punch_list_2026_05_30` for substitution map.