### PR TITLE
fix(container): drop COPY tests/ (excluded by .containerignore, tests not in runtime image)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,6 @@ COPY deno.json deno.lock* ./
 
 # Copy source code
 COPY src/ ./src/
-COPY tests/ ./tests/
 
 # Cache dependencies
 RUN deno cache src/server.ts


### PR DESCRIPTION
The Containerfile COPYs tests/ but .containerignore filters it out -> buildx 'no items matching glob' failure. Tests don't belong in the runtime image; removes the COPY.