### PR TITLE
feat(ci): attest build provenance

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write       # mint the OIDC token the attestation is signed with
+      attestations: write   # write the build-provenance attestation (the "claim")
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
       
@@ -35,6 +40,7 @@ jobs:
             type=sha
       
       - name: Build and push
+        id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v6
         with:
           context: .
@@ -42,3 +48,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest container provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Adds GitHub native build-provenance attestation to the container publish (id-token+attestations perms, digest captured from build-push, attest-build-provenance binds the pushed image). Part of the estate artifact-attestation rollout; mirrors the proven exemplar. Verify: gh attest verify oci://<image>:<tag> --repo <repo>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)